### PR TITLE
add spm support

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,8 @@
+@import url("./css/load1.css");
+@import url("./css/load2.css");
+@import url("./css/load3.css");
+@import url("./css/load4.css");
+@import url("./css/load5.css");
+@import url("./css/load6.css");
+@import url("./css/load7.css");
+@import url("./css/load8.css");

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "homepage": "https://github.com/lukehaas/css-loaders",
   "author": "Luke Haas",
   "license": "BSD",
   "devDependencies": {
@@ -13,5 +14,8 @@
     "grunt-contrib-jade": "~0.11.0",
     "grunt-contrib-less": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1"
+  },
+  "spm": {
+    "main": "./index.css"
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/css-loaders

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of css-loaders in spmjs, I can add it for your account after signing in http://spmjs.io.
