### PR TITLE
fix small error in fading dots animation

### DIFF
--- a/less/load5.less
+++ b/less/load5.less
@@ -51,7 +51,7 @@
     box-shadow:0em -2.6em 0em 0em fade(@foreground,20%),
     1.8em -1.8em 0 0em fade(@foreground,50%),
     2.5em 0em 0 0em fade(@foreground,70%),
-    1.75em 1.75em 0 0em fade(@foreground,20%),
+    1.75em 1.75em 0 0em fade(@foreground,100%),
     0em 2.5em 0 0em fade(@foreground,20%),
     -1.8em 1.8em 0 0em fade(@foreground,20%),
     -2.6em 0em 0 0em fade(@foreground,20%),


### PR DESCRIPTION
small glitch in 37.5 keyframe has the 100% dot set to 20%
