### PR TITLE
Fix positioning of overlays in load2 to get rid of ghost lines.

### DIFF
--- a/css/load2.css
+++ b/css/load2.css
@@ -28,8 +28,8 @@
   border-radius: 10.2em 0 0 10.2em;
   top: -0.1em;
   left: -0.1em;
-  -webkit-transform-origin: 5.2em 5.1em;
-  transform-origin: 5.2em 5.1em;
+  -webkit-transform-origin: 5.1em 5.1em;
+  transform-origin: 5.1em 5.1em;
   -webkit-animation: load2 2s infinite ease 1.5s;
   animation: load2 2s infinite ease 1.5s;
 }
@@ -39,9 +39,9 @@
   background: #0dc5c1;
   border-radius: 0 10.2em 10.2em 0;
   top: -0.1em;
-  left: 5.1em;
-  -webkit-transform-origin: 0px 5.1em;
-  transform-origin: 0px 5.1em;
+  left: 4.9em;
+  -webkit-transform-origin: 0.1em 5.1em;
+  transform-origin: 0.1em 5.1em;
   -webkit-animation: load2 2s infinite ease;
   animation: load2 2s infinite ease;
 }

--- a/less/load2.less
+++ b/less/load2.less
@@ -35,8 +35,8 @@
       border-radius: 10.2em 0 0 10.2em;
       top:-0.1em;
       left:-0.1em;
-      -webkit-transform-origin:5.2em 5.1em;
-      transform-origin:5.2em 5.1em;
+      -webkit-transform-origin:5.1em 5.1em;
+      transform-origin:5.1em 5.1em;
       -webkit-animation:load2 2s infinite ease 1.5s;
       animation:load2 2s infinite ease 1.5s;
     }
@@ -47,9 +47,9 @@
       background: @background;
       border-radius: 0 10.2em 10.2em 0;
       top:-0.1em;
-      left:5.1em;
-      -webkit-transform-origin:0px 5.1em;
-      transform-origin:0px 5.1em;
+      left:4.9em;
+      -webkit-transform-origin:0.1em 5.1em;
+      transform-origin:0.1em 5.1em;
       -webkit-animation:load2 2s infinite ease;
       animation:load2 2s infinite ease;
     }

--- a/sass/load2.scss
+++ b/sass/load2.scss
@@ -35,8 +35,8 @@ $foreground: #FFF;
       border-radius: 10.2em 0 0 10.2em;
       top:-0.1em;
       left:-0.1em;
-      -webkit-transform-origin:5.2em 5.1em;
-      transform-origin:5.2em 5.1em;
+      -webkit-transform-origin:5.1em 5.1em;
+      transform-origin:5.1em 5.1em;
       -webkit-animation:load2 2s infinite ease 1.5s;
       animation:load2 2s infinite ease 1.5s;
     }
@@ -47,9 +47,9 @@ $foreground: #FFF;
       background: $background;
       border-radius: 0 10.2em 10.2em 0;
       top:-0.1em;
-      left:5.1em;
-      -webkit-transform-origin:0px 5.1em;
-      transform-origin:0px 5.1em;
+      left:4.9em;
+      -webkit-transform-origin:0.1em 5.1em;
+      transform-origin:0.1em 5.1em;
       -webkit-animation:load2 2s infinite ease;
       animation:load2 2s infinite ease;
     }


### PR DESCRIPTION
There is a subtle displacement of the overlays in load2 which results in “ghost lines” where the circle is not completely covered. This commit fixes that issue by centering the overlays and there rotation origins.

![before](https://cloud.githubusercontent.com/assets/5417121/19307556/691dc70e-907b-11e6-8ff9-0374b5e794e8.png)
![after](https://cloud.githubusercontent.com/assets/5417121/19307555/6919d93c-907b-11e6-8b26-8b058c00acbf.png)
