### PR TITLE
spinner 1: use different CSS so that the height is fixed and doesn't wobble

### DIFF
--- a/css/load1.css
+++ b/css/load1.css
@@ -37,23 +37,19 @@
   0%,
   80%,
   100% {
-    box-shadow: 0 0;
-    height: 4em;
+    box-shadow: 0 0, 0 0;
   }
   40% {
-    box-shadow: 0 -2em;
-    height: 5em;
+    box-shadow: 0 -2em, 0 2em;
   }
 }
 @keyframes load1 {
   0%,
   80%,
   100% {
-    box-shadow: 0 0;
-    height: 4em;
+    box-shadow: 0 0, 0 0;
   }
   40% {
-    box-shadow: 0 -2em;
-    height: 5em;
+    box-shadow: 0 -2em, 0 2em;
   }
 }


### PR DESCRIPTION
Because the `height` CSS property was changing with the animation, it was causing some UI issues. The same behaviour can be achieved with `box-shadow` while keeping `height` constant.  See https://github.com/daattali/shinycssloaders/issues/81